### PR TITLE
Fix: use slot start instead of request start

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -320,16 +320,8 @@ contract Marketplace is Collateral, Proofs {
     return _timeout();
   }
 
-  function proofStart(SlotId slotId) public view override returns (uint256) {
-    return requestStart(_slot(slotId).requestId);
-  }
-
   function proofEnd(SlotId slotId) public view override returns (uint256) {
     return requestEnd(_slot(slotId).requestId);
-  }
-
-  function requestStart(RequestId requestId) public view returns (uint256) {
-    return _context(requestId).startedAt;
   }
 
   function requestEnd(RequestId requestId) public view returns (uint256) {

--- a/contracts/TestProofs.sol
+++ b/contracts/TestProofs.sol
@@ -5,7 +5,6 @@ import "./Proofs.sol";
 
 // exposes internal functions of Proofs for testing
 contract TestProofs is Proofs {
-  mapping(SlotId => uint256) private starts;
   mapping(SlotId => uint256) private ends;
 
   constructor(
@@ -17,10 +16,6 @@ contract TestProofs is Proofs {
   // solhint-disable-next-line no-empty-blocks
   {
 
-  }
-
-  function proofStart(SlotId slotId) public view override returns (uint256) {
-    return starts[slotId];
   }
 
   function proofEnd(SlotId slotId) public view override returns (uint256) {
@@ -57,10 +52,6 @@ contract TestProofs is Proofs {
 
   function markProofAsMissing(SlotId id, Period _period) public {
     _markProofAsMissing(id, _period);
-  }
-
-  function setProofStart(SlotId id, uint256 start) public {
-    starts[id] = start;
   }
 
   function setProofEnd(SlotId id, uint256 end) public {

--- a/test/Proofs.test.js
+++ b/test/Proofs.test.js
@@ -37,7 +37,6 @@ describe("Proofs", function () {
 
   describe("general", function () {
     beforeEach(async function () {
-      await proofs.setProofStart(slotId, await currentTime())
       await proofs.setProofEnd(slotId, (await currentTime()) + duration)
     })
 
@@ -90,7 +89,6 @@ describe("Proofs", function () {
       let id2 = hexlify(randomBytes(32))
       let id3 = hexlify(randomBytes(32))
       for (let slotId of [id1, id2, id3]) {
-        await proofs.setProofStart(slotId, await currentTime())
         await proofs.setProofEnd(slotId, (await currentTime()) + duration)
         await proofs.startRequiringProofs(slotId, probability)
       }
@@ -122,7 +120,6 @@ describe("Proofs", function () {
     }
 
     beforeEach(async function () {
-      await proofs.setProofStart(slotId, await currentTime())
       await proofs.setProofEnd(slotId, (await currentTime()) + duration)
       await proofs.startRequiringProofs(slotId, probability)
       await advanceTimeTo(periodEnd(periodOf(await currentTime())))
@@ -157,7 +154,6 @@ describe("Proofs", function () {
     const proof = hexlify(randomBytes(42))
 
     beforeEach(async function () {
-      await proofs.setProofStart(slotId, await currentTime())
       await proofs.setProofEnd(slotId, (await currentTime()) + duration)
       await proofs.startRequiringProofs(slotId, probability)
     })


### PR DESCRIPTION
Proofs should be required from the moment a slot is filled, not from the moment a request is submitted.

Reverts part of #28.