### PR TITLE
get request from slot id

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -216,6 +216,16 @@ contract Marketplace is Collateral, Proofs, StateRetrieval {
     return _slots[slotId].host;
   }
 
+  function getRequestFromSlotId(SlotId slotId)
+    public
+    view
+    slotIsNotFree(slotId)
+    returns (Request memory)
+  {
+    Slot storage slot = slots[slotId];
+    return requests[slot.requestId];
+  }
+
   modifier requestIsKnown(RequestId requestId) {
     require(_requests[requestId].client != address(0), "Unknown request");
     _;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -222,8 +222,8 @@ contract Marketplace is Collateral, Proofs, StateRetrieval {
     slotIsNotFree(slotId)
     returns (Request memory)
   {
-    Slot storage slot = slots[slotId];
-    return requests[slot.requestId];
+    Slot storage slot = _slots[slotId];
+    return _requests[slot.requestId];
   }
 
   modifier requestIsKnown(RequestId requestId) {

--- a/test/requests.js
+++ b/test/requests.js
@@ -1,3 +1,5 @@
+const { Assertion } = require("chai")
+
 const RequestState = {
   New: 0,
   Started: 1,
@@ -14,4 +16,33 @@ const SlotState = {
   Paid: 4,
 }
 
-module.exports = { RequestState, SlotState }
+const enableRequestAssertions = function () {
+  // language chain method
+  Assertion.addMethod("request", function (request) {
+    var actual = this._obj
+
+    this.assert(
+      actual.client === request.client,
+      "expected request #{this} to have client #{exp} but got #{act}",
+      "expected request #{this} to not have client #{act}, expected #{exp}",
+      request.client, // expected
+      actual.client // actual
+    )
+    this.assert(
+      actual.expiry == request.expiry,
+      "expected request #{this} to have expiry #{exp} but got #{act}",
+      "expected request #{this} to not have expiry #{act}, expected #{exp}",
+      request.expiry, // expected
+      actual.expiry // actual
+    )
+    this.assert(
+      actual.nonce === request.nonce,
+      "expected request #{this} to have nonce #{exp} but got #{act}",
+      "expected request #{this} to not have nonce #{act}, expected #{exp}",
+      request.nonce, // expected
+      actual.nonce // actual
+    )
+  })
+}
+
+module.exports = { RequestState, SlotState, enableRequestAssertions }


### PR DESCRIPTION
- Add public function to get request from slot id.
- Add chai test assertion that compares requests. Usage: `expect(await marketplace.getRequestFromSlotId(slotId(slot))).to.be.request(request)`

This is used when restoring active sale: a node calls `mySlots`, returning an array of `SlotIds`, which are then iterated  to get the originating request details from the contract.