### PR TITLE
Formal verification with solidity compiler

### DIFF
--- a/hardhat.modelcheck.config.js
+++ b/hardhat.modelcheck.config.js
@@ -1,0 +1,11 @@
+const config = require("./hardhat.config")
+
+config.solidity.settings.modelChecker = {
+  engine: "chc",
+  showUnproved: true,
+  contracts: {
+    "contracts/TestCollateral.sol": ["TestCollateral"],
+  },
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "npm run lint && hardhat test",
     "start": "hardhat node --export deployment-localhost.json",
     "format": "prettier --write contracts/**/*.sol test/**/*.js",
-    "lint": "solhint contracts/**.sol"
+    "lint": "solhint contracts/**.sol",
+    "modelcheck": "hardhat compile --config hardhat.modelcheck.config.js --force"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.1",


### PR DESCRIPTION
Attempt at model checking with the SMT checker from the solidity compiler. It does not seem to be usable for us just yet. This PR is meant as documentation for future attempts to use the SMT checker.

#### Observations ####

Both the BMC and the CHC engines are not able to deal with the relatively simple [invariant](https://github.com/status-im/codex-contracts-eth/blob/cde543626236bd48188354d842cbe1513052c560/contracts/Collateral.sol#L60) from `Collateral.sol`. This appears to be a [know restriction](https://docs.soliditylang.org/en/v0.8.17/smtchecker.html#function-calls) when calling external functions without implementation. Because we depend quite heavily on an IERC20 interface for our money flows, this is quite unfortunate.

On Debian it won't recognize the installed z3 library. For it to work it currently requires:
```bash
cd /usr/lib/x86_64-linux-gnu/
sudo ln -s libz3.so.4 libz3.so.4.8
```