### PR TITLE
Tweak test settings

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -12,6 +12,11 @@ module.exports = {
       },
     },
   },
+  mocha: {
+    bail: true,
+    slow: 200,
+    timeout: 30 * 1000,
+  },
   namedAccounts: {
     deployer: { default: 0 },
   },


### PR DESCRIPTION
- stop on first failure (quick feedback)
- do not warn about slow test before 100 ms (solidity tests are inherently slow)
- set test timeout to 30 seconds
- ~~run tests in parallel in CI~~ (did not make CI faster)
