### PR TITLE
fix: reset missed counter when slot is freed

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -152,6 +152,7 @@ contract Marketplace is Proofs, StateRetrieval {
     delete _slots[slotId];
     context.slotsFilled -= 1;
     emit SlotFreed(requestId, slotId);
+    resetMissingProofs(slotId);
 
     Request storage request = _requests[requestId];
     uint256 slotsLost = request.ask.slots - context.slotsFilled;

--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -25,6 +25,10 @@ abstract contract Proofs is Periods {
     return _missed[slotId];
   }
 
+  function resetMissingProofs(SlotId slotId) internal {
+    _missed[slotId] = 0;
+  }
+
   function _startRequiringProofs(SlotId id, uint256 probability) internal {
     _slotStarts[id] = block.timestamp;
     _probabilities[id] = probability;


### PR DESCRIPTION
When a slot is freed after the host misses too many proofs, the "missed proofs counter" is not reset, and hence the new host that fills the freed slot will have a non-zero "missed proofs counter". While this does not impact functionality as the logic uses modulo in the implementation, if somebody queries the `missingProofs()` method directly, he would be surprised with the number he would potentially get.