### PR TITLE
retrieve active slot for sales state restoration

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -31,12 +31,18 @@ contract Marketplace is Proofs, StateRetrieval {
   struct Slot {
     SlotState state;
     RequestId requestId;
+    uint256 slotIndex;
 
     /// @notice Tracks the current amount of host's collateral that is to be payed out at the end of Slot's lifespan.
     /// @dev When Slot is filled, the collateral is collected in amount of request.ask.collateral
     /// @dev When Host is slashed for missing a proof the slashed amount is reflected in this variable
     uint256 currentCollateral;
     address host;
+  }
+
+  struct ActiveSlot {
+    Request request;
+    uint256 slotIndex;
   }
 
   constructor(
@@ -79,6 +85,7 @@ contract Marketplace is Proofs, StateRetrieval {
     SlotId slotId = Requests.slotId(requestId, slotIndex);
     Slot storage slot = _slots[slotId];
     slot.requestId = requestId;
+    slot.slotIndex = slotIndex;
 
     require(slotState(slotId) == SlotState.Free, "Slot is not free");
 
@@ -213,14 +220,17 @@ contract Marketplace is Proofs, StateRetrieval {
     require(token.transfer(msg.sender, amount), "Withdraw failed");
   }
 
-  function getRequestFromSlotId(SlotId slotId)
+  function getActiveSlot(SlotId slotId)
     public
     view
     slotIsNotFree(slotId)
-    returns (Request memory)
+    returns (ActiveSlot memory)
   {
     Slot storage slot = _slots[slotId];
-    return _requests[slot.requestId];
+    ActiveSlot memory activeSlot;
+    activeSlot.request = _requests[slot.requestId];
+    activeSlot.slotIndex = slot.slotIndex;
+    return activeSlot;
   }
 
   modifier requestIsKnown(RequestId requestId) {

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -140,16 +140,16 @@ describe("Marketplace", function () {
     })
 
     it("fails to retrieve a request of an empty slot", async function () {
-      expect(marketplace.getRequestFromSlotId(slotId(slot))).to.be.revertedWith(
+      expect(marketplace.getActiveSlot(slotId(slot))).to.be.revertedWith(
         "Slot is free"
       )
     })
 
     it("allows retrieval of request of a filled slot", async function () {
       await marketplace.fillSlot(slot.request, slot.index, proof)
-      expect(
-        await marketplace.getRequestFromSlotId(slotId(slot))
-      ).to.be.request(request)
+      let activeSlot = await marketplace.getActiveSlot(slotId(slot))
+      expect(activeSlot.request).to.be.request(request)
+      expect(activeSlot.slotIndex).to.equal(slot.index)
     })
 
     it("is rejected when proof is incorrect", async function () {


### PR DESCRIPTION
Store slotIndex in slot struct and expose the slot via getActiveSlot. This is to be used when restoring state in the sales module after a node restart.