### PR TITLE
build: make sure marketplace is on predefined address

### DIFF
--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -31,7 +31,6 @@ async function aliasContract({deployments, network}) {
     const marketplaceDeployment = await deployments.get("Marketplace")
 
     if (marketplaceDeployment.address === MARKETPLACE_HARDCODED_ADDRESS) {
-      console.log('Marketplace is deployed to expected address. Aborting aliasing.')
       return 
     }
 

--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -1,3 +1,5 @@
+const MARKETPLACE_HARDCODED_ADDRESS = "0x59b670e9fA9D0A427751Af201D676719a970857b"
+
 async function deployMarketplace({ deployments, getNamedAccounts }) {
   const token = await deployments.get("TestToken")
   const configuration = {
@@ -24,9 +26,24 @@ async function mine256blocks({ network, ethers }) {
   }
 }
 
+async function aliasContract({deployments, network}) {
+  if (network.tags.local) {
+    const marketplaceDeployment = await deployments.get("Marketplace")
+
+    if (marketplaceDeployment.address === MARKETPLACE_HARDCODED_ADDRESS) {
+      console.log('Marketplace is deployed to expected address. Aborting aliasing.')
+      return 
+    }
+
+    console.log(`Aliasing marketplace from address ${marketplaceDeployment.address} to ${MARKETPLACE_HARDCODED_ADDRESS}`)
+    await ethers.provider.send("hardhat_setCode", [MARKETPLACE_HARDCODED_ADDRESS, marketplaceDeployment.address])
+  }
+}
+
 module.exports = async (environment) => {
   await mine256blocks(environment)
   await deployMarketplace(environment)
+  await aliasContract(environment)
 }
 
 module.exports.tags = ["Marketplace"]


### PR DESCRIPTION
Needed for https://github.com/status-im/nim-codex/issues/372

It is not needed per-se as it seems that the address should be deterministic, but if there would be a case when we add a transaction into the deployment script, then the address would change, so this is just a safe guard to make it future-proof.